### PR TITLE
Add a font weight to the alert title

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,6 +11,7 @@
     flex-direction: row;
     align-items: center;
     color: var(--border-color);
+    font-weight: 500;
 }
 
 .markdown-alert .markdown-alert-icon {


### PR DESCRIPTION
Greetings! I'd like to add a font weight to the alert title like on GitHub. The default value is 500, or `--base-text-weight-medium`.

After doing some research on the source code, I noticed that it is possible to apply `font-weight: 500;` (and higher) to the `<span>` element without messing up the icons.

See the screenshots for comparison.

<details><summary>Screenshots</summary>

![No font weight](https://github.com/ByPikod/vscode-markdown-alert/assets/84022504/293596aa-d38d-428e-80ee-95b677541478)
![Font weight is 500](https://github.com/ByPikod/vscode-markdown-alert/assets/84022504/4c448e35-3c8f-4646-b925-0f81ac520403)
![Font weight is 700 (for comparison)](https://github.com/ByPikod/vscode-markdown-alert/assets/84022504/b17836df-c003-4c6d-a665-48e23180e6ae)

</details>

My VS Code also inadvertently fixed a missing newline, but it wasn't critical.